### PR TITLE
Fix auto-play and resume song issues

### DIFF
--- a/src/hooks/useSpotifyControls.ts
+++ b/src/hooks/useSpotifyControls.ts
@@ -90,11 +90,11 @@ export const useSpotifyControls = ({
           (currentTrack && state.track_window.current_track.id !== currentTrack.id)) {
         onPlay();
       } else {
-        // If the current track matches and it's just paused, resume it
+        // If the current track matches
         if (state.paused) {
           await spotifyPlayer.resume();
         } else {
-          onPlay();
+          // Track is already playing, do nothing (just sync UI)
         }
       }
     }

--- a/src/hooks/useSpotifyControls.ts
+++ b/src/hooks/useSpotifyControls.ts
@@ -77,13 +77,28 @@ export const useSpotifyControls = ({
     checkLikeStatus();
   }, [currentTrack?.id]);
 
-  const handlePlayPause = useCallback(() => {
+  const handlePlayPause = useCallback(async () => {
     if (isPlaying) {
       onPause();
     } else {
-      onPlay();
+      // Check current playback state to decide between play and resume
+      const state = await spotifyPlayer.getCurrentState();
+      
+      // If there's no current track or the current track doesn't match what we expect,
+      // use onPlay to start playing the selected track
+      if (!state || !state.track_window?.current_track || 
+          (currentTrack && state.track_window.current_track.id !== currentTrack.id)) {
+        onPlay();
+      } else {
+        // If the current track matches and it's just paused, resume it
+        if (state.paused) {
+          await spotifyPlayer.resume();
+        } else {
+          onPlay();
+        }
+      }
     }
-  }, [isPlaying, onPlay, onPause]);
+  }, [isPlaying, onPlay, onPause, currentTrack]);
 
   const handleMuteToggle = useCallback(() => {
     const newMutedState = !isMuted;


### PR DESCRIPTION
Refactor audio playback and controls to fix auto-play and play/resume logic.

This PR addresses two main issues: unreliable auto-play of the first song when a playlist loads, and the play button incorrectly attempting to resume the last played track instead of starting the currently selected one. Changes include improved state checking for playback, more robust device activation, and refined play/pause button behavior to ensure the correct track is always played or resumed.