### PR TITLE
Add toggle option for glow effect

### DIFF
--- a/src/components/AlbumArt.tsx
+++ b/src/components/AlbumArt.tsx
@@ -90,8 +90,8 @@ const AlbumArt: React.FC<AlbumArtProps> = memo(({ currentTrack = null, accentCol
         invert: false,
       }}>
         <AccentColorGlowOverlay
-          glowIntensity={glowIntensity || 100}
-          glowRate={glowRate || DEFAULT_GLOW_RATE}
+          glowIntensity={glowIntensity ?? 100}
+          glowRate={glowRate ?? DEFAULT_GLOW_RATE}
           accentColor={accentColor || '#000000'}
           backgroundImage={currentTrack?.image}
         />

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -104,6 +104,7 @@ const AudioPlayerComponent = () => {
     showPlaylist,
     accentColor,
     showVisualEffects,
+    glowEnabled,
     glowIntensity,
     glowRate,
     glowMode,
@@ -118,6 +119,7 @@ const AudioPlayerComponent = () => {
     setShowPlaylist,
     setAccentColor,
     setShowVisualEffects,
+    setGlowEnabled,
     setGlowIntensity,
     setGlowRate,
     setGlowMode,
@@ -353,7 +355,7 @@ const AudioPlayerComponent = () => {
         <LoadingCard backgroundImage={currentTrack?.image}>
 
           <CardContent style={{ position: 'relative', zIndex: 2 }}>
-            <AlbumArt currentTrack={currentTrack} accentColor={accentColor} glowIntensity={effectiveGlow.intensity} glowRate={effectiveGlow.rate} albumFilters={albumFilters} />
+            <AlbumArt currentTrack={currentTrack} accentColor={accentColor} glowIntensity={glowEnabled ? effectiveGlow.intensity : 0} glowRate={effectiveGlow.rate} albumFilters={albumFilters} />
           </CardContent>
           <CardContent style={{ position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 2 }}>
             <Suspense fallback={<div style={{ height: '80px', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'rgba(255,255,255,0.7)' }}>Loading controls...</div>}>
@@ -386,6 +388,8 @@ const AudioPlayerComponent = () => {
               filters={albumFilters}
               onFilterChange={handleFilterChange}
               onResetFilters={handleResetFilters}
+              glowEnabled={glowEnabled}
+              setGlowEnabled={setGlowEnabled}
               glowIntensity={glowIntensity}
               setGlowIntensity={setGlowIntensity}
               glowRate={typeof glowRate === 'number' ? glowRate : DEFAULT_GLOW_RATE}

--- a/src/components/VisualEffectsMenu.tsx
+++ b/src/components/VisualEffectsMenu.tsx
@@ -19,6 +19,8 @@ interface VisualEffectsMenuProps {
   onFilterChange: (filterName: string, value: number | boolean) => void;
   onResetFilters: () => void;
   // Glow controls
+  glowEnabled: boolean;
+  setGlowEnabled: (v: boolean) => void;
   glowIntensity: number;
   setGlowIntensity: (v: number) => void;
   glowRate: number;
@@ -237,6 +239,8 @@ export const VisualEffectsMenu: React.FC<VisualEffectsMenuProps> = memo(({
   filters,
   onFilterChange,
   onResetFilters,
+  glowEnabled,
+  setGlowEnabled,
   glowIntensity,
   setGlowIntensity,
   glowRate,
@@ -301,103 +305,119 @@ export const VisualEffectsMenu: React.FC<VisualEffectsMenuProps> = memo(({
             <FilterGrid>
               <ControlGroup>
                 <ControlLabel>
-                  Glow Mode
+                  Enable Glow
                   <ToggleButton
                     $accentColor={accentColor}
-                    $isActive={glowMode === 'per-album'}
-                    onClick={() => setGlowMode(glowMode === 'global' ? 'per-album' : 'global')}
+                    $isActive={glowEnabled}
+                    onClick={() => setGlowEnabled(!glowEnabled)}
                   >
-                    {glowMode === 'per-album' ? 'Per Album' : 'Global'}
+                    {glowEnabled ? 'On' : 'Off'}
                   </ToggleButton>
                 </ControlLabel>
               </ControlGroup>
-              {glowMode === 'per-album' && currentAlbumId ? (
+              {glowEnabled && (
                 <>
                   <ControlGroup>
                     <ControlLabel>
-                      Album Glow Intensity
-                      <ControlValue>{(perAlbumGlow[currentAlbumId]?.intensity ?? 100)}</ControlValue>
+                      Glow Mode
+                      <ToggleButton
+                        $accentColor={accentColor}
+                        $isActive={glowMode === 'per-album'}
+                        onClick={() => setGlowMode(glowMode === 'global' ? 'per-album' : 'global')}
+                      >
+                        {glowMode === 'per-album' ? 'Per Album' : 'Global'}
+                      </ToggleButton>
                     </ControlLabel>
-                    <Slider
-                      type="range"
-                      min={0}
-                      max={100}
-                      value={perAlbumGlow[currentAlbumId]?.intensity ?? 100}
-                      onChange={e => {
-                        setPerAlbumGlow({
-                          ...perAlbumGlow,
-                          [currentAlbumId]: {
-                            intensity: Number(e.target.value),
-                            rate: perAlbumGlow[currentAlbumId]?.rate ?? DEFAULT_GLOW_RATE
-                          }
-                        });
-                      }}
-                      $accentColor={accentColor}
-                    />
                   </ControlGroup>
-                  <ControlGroup>
-                    <ControlLabel>
-                      Album Glow Rate
-                      <ControlValue>{(perAlbumGlow[currentAlbumId]?.rate ?? DEFAULT_GLOW_RATE).toFixed(2)}s</ControlValue>
-                    </ControlLabel>
-                    <Slider
-                      type="range"
-                      min={0.5}
-                      max={5}
-                      step={0.01}
-                      value={perAlbumGlow[currentAlbumId]?.rate ?? DEFAULT_GLOW_RATE}
-                      onChange={e => {
-                        setPerAlbumGlow({
-                          ...perAlbumGlow,
-                          [currentAlbumId]: {
-                            intensity: perAlbumGlow[currentAlbumId]?.intensity ?? 100,
-                            rate: Number(e.target.value)
-                          }
-                        });
-                      }}
-                      $accentColor={accentColor}
-                    />
-                  </ControlGroup>
+                  {glowMode === 'per-album' && currentAlbumId ? (
+                    <>
+                      <ControlGroup>
+                        <ControlLabel>
+                          Album Glow Intensity
+                          <ControlValue>{(perAlbumGlow[currentAlbumId]?.intensity ?? 100)}</ControlValue>
+                        </ControlLabel>
+                        <Slider
+                          type="range"
+                          min={0}
+                          max={100}
+                          value={perAlbumGlow[currentAlbumId]?.intensity ?? 100}
+                          onChange={e => {
+                            setPerAlbumGlow({
+                              ...perAlbumGlow,
+                              [currentAlbumId]: {
+                                intensity: Number(e.target.value),
+                                rate: perAlbumGlow[currentAlbumId]?.rate ?? DEFAULT_GLOW_RATE
+                              }
+                            });
+                          }}
+                          $accentColor={accentColor}
+                        />
+                      </ControlGroup>
+                      <ControlGroup>
+                        <ControlLabel>
+                          Album Glow Rate
+                          <ControlValue>{(perAlbumGlow[currentAlbumId]?.rate ?? DEFAULT_GLOW_RATE).toFixed(2)}s</ControlValue>
+                        </ControlLabel>
+                        <Slider
+                          type="range"
+                          min={0.5}
+                          max={5}
+                          step={0.01}
+                          value={perAlbumGlow[currentAlbumId]?.rate ?? DEFAULT_GLOW_RATE}
+                          onChange={e => {
+                            setPerAlbumGlow({
+                              ...perAlbumGlow,
+                              [currentAlbumId]: {
+                                intensity: perAlbumGlow[currentAlbumId]?.intensity ?? 100,
+                                rate: Number(e.target.value)
+                              }
+                            });
+                          }}
+                          $accentColor={accentColor}
+                        />
+                      </ControlGroup>
+                      <div style={{ fontSize: '0.8rem', color: '#aaa', marginBottom: '0.5rem' }}>
+                        Album: {currentAlbumName || currentAlbumId}
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <ControlGroup>
+                        <ControlLabel>
+                          Glow Intensity
+                          <ControlValue>{glowIntensity}</ControlValue>
+                        </ControlLabel>
+                        <Slider
+                          type="range"
+                          min={0}
+                          max={100}
+                          value={glowIntensity}
+                          onChange={e => setGlowIntensity(Number(e.target.value))}
+                          $accentColor={accentColor}
+                        />
+                      </ControlGroup>
+                      <ControlGroup>
+                        <ControlLabel>
+                          Glow Rate
+                          <ControlValue>{glowRate.toFixed(2)}s</ControlValue>
+                        </ControlLabel>
+                        <Slider
+                          type="range"
+                          min={0.5}
+                          max={5}
+                          step={0.01}
+                          value={glowRate}
+                          onChange={e => setGlowRate(Number(e.target.value))}
+                          $accentColor={accentColor}
+                        />
+                      </ControlGroup>
+                    </>
+                  )}
                   <div style={{ fontSize: '0.8rem', color: '#aaa', marginBottom: '0.5rem' }}>
-                    Album: {currentAlbumName || currentAlbumId}
+                    Effective: Intensity {effectiveGlow.intensity}, Rate {effectiveGlow.rate.toFixed(2)}s
                   </div>
                 </>
-              ) : (
-                <>
-                  <ControlGroup>
-                    <ControlLabel>
-                      Glow Intensity
-                      <ControlValue>{glowIntensity}</ControlValue>
-                    </ControlLabel>
-                    <Slider
-                      type="range"
-                      min={0}
-                      max={100}
-                      value={glowIntensity}
-                      onChange={e => setGlowIntensity(Number(e.target.value))}
-                      $accentColor={accentColor}
-                    />
-                  </ControlGroup>
-                  <ControlGroup>
-                    <ControlLabel>
-                      Glow Rate
-                      <ControlValue>{glowRate.toFixed(2)}s</ControlValue>
-                    </ControlLabel>
-                    <Slider
-                      type="range"
-                      min={0.5}
-                      max={5}
-                      step={0.01}
-                      value={glowRate}
-                      onChange={e => setGlowRate(Number(e.target.value))}
-                      $accentColor={accentColor}
-                    />
-                  </ControlGroup>
-                </>
               )}
-              <div style={{ fontSize: '0.8rem', color: '#aaa', marginBottom: '0.5rem' }}>
-                Effective: Intensity {effectiveGlow.intensity}, Rate {effectiveGlow.rate.toFixed(2)}s
-              </div>
             </FilterGrid>
           </FilterSection>
           {/* Album Art Filters Section */}

--- a/src/hooks/usePlayerState.ts
+++ b/src/hooks/usePlayerState.ts
@@ -23,6 +23,7 @@ export interface PlayerState {
   showPlaylist: boolean;
   accentColor: string;
   showVisualEffects: boolean;
+  glowEnabled: boolean;
   glowIntensity: number;
   glowRate: number;
   glowMode: 'global' | 'per-album';
@@ -40,6 +41,11 @@ export const usePlayerState = () => {
   const [showPlaylist, setShowPlaylist] = useState(false);
   const [accentColor, setAccentColor] = useState<string>(theme.colors.accent);
   const [showVisualEffects, setShowVisualEffects] = useState(false);
+  
+  const [glowEnabled, setGlowEnabled] = useState<boolean>(() => {
+    const saved = localStorage.getItem('vorbis-player-glow-enabled');
+    return saved ? JSON.parse(saved) : true;
+  });
   
   const [glowIntensity, setGlowIntensity] = useState<number>(() => {
     const saved = localStorage.getItem('vorbis-player-glow-intensity');
@@ -123,6 +129,10 @@ export const usePlayerState = () => {
 
   // Persist glow settings to localStorage
   useEffect(() => {
+    localStorage.setItem('vorbis-player-glow-enabled', JSON.stringify(glowEnabled));
+  }, [glowEnabled]);
+  
+  useEffect(() => {
     localStorage.setItem('vorbis-player-glow-intensity', glowIntensity.toString());
   }, [glowIntensity]);
   
@@ -168,6 +178,7 @@ export const usePlayerState = () => {
     showPlaylist,
     accentColor,
     showVisualEffects,
+    glowEnabled,
     glowIntensity,
     glowRate,
     glowMode,
@@ -184,6 +195,7 @@ export const usePlayerState = () => {
     setShowPlaylist,
     setAccentColor,
     setShowVisualEffects,
+    setGlowEnabled,
     setGlowIntensity,
     setGlowRate,
     setGlowMode,


### PR DESCRIPTION
Add a toggle to enable/disable the glow effect and fix its functionality.

The initial implementation used `glowIntensity || 100`, which caused `0` (falsy) to default to `100`, preventing the glow from being truly disabled. This is fixed by using the nullish coalescing operator `%3F%3F` instead.