### PR TITLE
Adjust song info layout

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -28,11 +28,11 @@ const Container = styled.div`
 
 const ContentWrapper = styled.div`
   width: 1024px;
-  height: 1126px;
+  height: 1186px;
 
   @media (max-height: ${theme.breakpoints.lg}) {
     width: 768px;
-    height: 872px;
+    height: 922px;
   }
 
   margin: 0 auto;

--- a/src/components/SpotifyPlayerControls.tsx
+++ b/src/components/SpotifyPlayerControls.tsx
@@ -22,6 +22,17 @@ const PlayerControlsContainer = styled.div`
   padding: ${sm} ${lg} ${lg} ${lg};
 `;
 
+// New components for the track info row
+const TrackInfoOnlyRow = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: ${({ theme }: any) => theme.spacing.xs};
+  width: 100%;
+  padding: 0 ${({ theme }: any) => theme.spacing.md};
+`;
+
 const PlayerTrackName = styled.div`
   font-weight: ${({ theme }: any) => theme.fontWeight.semibold};
   font-size: ${({ theme }: any) => theme.fontSize.base};
@@ -30,15 +41,16 @@ const PlayerTrackName = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  width: 100%;
 `;
 
 const PlayerTrackArtist = styled.div`
   font-size: ${({ theme }: any) => theme.fontSize.sm};
-  margin-top: ${({ theme }: any) => theme.spacing.xs};
   color: ${({ theme }: any) => theme.colors.gray[400]};
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  width: 100%;
 `;
 
 const TrackInfoRow = styled.div`
@@ -279,11 +291,16 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({ currentTrack, 
 
   return (
     <PlayerControlsContainer>
-      {/* Track Info Row with three columns */}
+      {/* New Track Info Row - Song name and artist only */}
+      <TrackInfoOnlyRow>
+        <PlayerTrackName>{currentTrack?.name || 'No track selected'}</PlayerTrackName>
+        <PlayerTrackArtist>{currentTrack?.artists || ''}</PlayerTrackArtist>
+      </TrackInfoOnlyRow>
+
+      {/* Controls Row - now without track info in the left section */}
       <TrackInfoRow style={{ position: 'relative' }}>
         <TrackInfoLeft>
-          <PlayerTrackName>{currentTrack?.name || 'No track selected'}</PlayerTrackName>
-          <PlayerTrackArtist>{currentTrack?.artists || ''}</PlayerTrackArtist>
+          {/* Left side is now empty - could be used for other controls if needed */}
         </TrackInfoLeft>
         <TrackInfoCenter>
           <ControlButton accentColor={accentColor} onClick={onPrevious}>
@@ -411,5 +428,4 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({ currentTrack, 
 
 SpotifyPlayerControls.displayName = 'SpotifyPlayerControls';
 
-export default SpotifyPlayerControls;
-// ... existing code ... 
+export default SpotifyPlayerControls; 


### PR DESCRIPTION
Move song name and artist to a dedicated row above player controls and extend app card height for improved layout.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents%3Fid=bc-7e8ce1a2-9bc6-4c95-9480-3b87c7f30a10) · [Cursor](https://cursor.com/background-agent%3FbcId=bc-7e8ce1a2-9bc6-4c95-9480-3b87c7f30a10)