### PR TITLE
Streamline visual effects menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ A modern Spotify music player with a sleek, unified interface designed for enjoy
 - **Dynamic Album Art**: Beautiful album artwork display with customizable visual effects
 - **Integrated Player Card**: Clean, unified interface with elegant design
 - **Streamlined Visual Effects**: Simplified visual effects system with easy on/off toggle and intuitive controls
-- **Custom Album Filters**: Adjustable brightness, saturation, sepia, contrast, and invert effects for personalized visual experience
-- **Enhanced Glow System**: Simplified glow controls with three intensity levels (Low, Medium, High) and rate options (Slow, Medium, Fast)
+- **Custom Album Filters**: Refined set of essential filters - brightness, saturation, sepia, and contrast - for optimal visual customization
+- **Enhanced Glow System**: Simplified glow controls with three intensity levels (Less/Normal/More) and rate options (Slower/Normal/Faster)
 - **Responsive Design**: Smooth transitions and loading states throughout the interface
 
 ### 🎛️ User Interface
@@ -118,7 +118,7 @@ A modern Spotify music player with a sleek, unified interface designed for enjoy
 - **Spotify Integration**: High-quality music from your personal playlists and liked songs library
 - **Liked Songs Support**: Full access to your Spotify Liked Songs with automatic shuffle for music discovery
 - **Smart Color Extraction**: Dynamic color theming based on album artwork
-- **Visual Effects**: Streamlined visual effects system with simplified glow controls and customizable album filters
+- **Visual Effects**: Streamlined visual effects system with optimized glow controls and refined album filters (brightness, saturation, sepia, contrast)
 - **Automatic Progression**: Seamless transitions between tracks with continuous playback
 - **Album Art Display**: Beautiful artwork display with customizable visual effects
 
@@ -251,8 +251,10 @@ public/
 - **Optimized Icons**: Consistent 1.5rem sizing across all control icons
 - **Streamlined Visual Effects**: Simplified visual effects system with intuitive three-option controls (Less/Normal/More)
 - **Simplified Glow Controls**: Removed complex per-album glow settings in favor of unified global controls
-- **Enhanced Filter Options**: Refined brightness, saturation, sepia, and contrast ranges for better visual results
+- **Refined Filter Set**: Focused on essential filters (brightness, saturation, sepia, contrast) with optimized default values
+- **Enhanced Filter Options**: Improved brightness default (110%) and refined glow intensity range (95-125) for better visual results
 - **Improved Settings Persistence**: Visual effects settings are preserved when toggling effects on/off
+- **Cleaner Codebase**: Removed unused blur and hue filters, eliminated invert option for a more focused experience
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ A modern Spotify music player with a sleek, unified interface designed for enjoy
 ### 🎨 Visual Experience  
 - **Dynamic Album Art**: Beautiful album artwork display with customizable visual effects
 - **Integrated Player Card**: Clean, unified interface with elegant design
-- **Custom Visual Effects**: Adjustable glow effects to personalize your experience
+- **Streamlined Visual Effects**: Simplified visual effects system with easy on/off toggle and intuitive controls
+- **Custom Album Filters**: Adjustable brightness, saturation, sepia, contrast, and invert effects for personalized visual experience
+- **Enhanced Glow System**: Simplified glow controls with three intensity levels (Low, Medium, High) and rate options (Slow, Medium, Fast)
 - **Responsive Design**: Smooth transitions and loading states throughout the interface
 
 ### 🎛️ User Interface
@@ -27,6 +29,8 @@ A modern Spotify music player with a sleek, unified interface designed for enjoy
 - **Timeline-Integrated Controls**: Settings and volume controls positioned along the timeline for compact, streamlined interface
 - **Fixed-Size Layout**: Consistent 768px x 880px dimensions for predictable layout and optimal viewing experience
 - **Unified Settings Modal**: Comprehensive settings interface with visual effects and configuration options
+- **Streamlined Visual Effects Toggle**: Single-button visual effects control that toggles all visual enhancements on/off with preserved settings
+- **Simplified Visual Effects Menu**: Redesigned visual effects interface with three-option selections for easier customization
 - **Sliding Playlist Drawer**: Space-saving collapsible playlist accessible from anywhere with 1.5rem consistent icon sizing
 - **Album Art Display**: Prominent album artwork with customizable visual effects
 - **Warm Color Palette**: Warmer background tones (rgba(85, 78, 78, 0.56)) for comfortable viewing
@@ -114,7 +118,7 @@ A modern Spotify music player with a sleek, unified interface designed for enjoy
 - **Spotify Integration**: High-quality music from your personal playlists and liked songs library
 - **Liked Songs Support**: Full access to your Spotify Liked Songs with automatic shuffle for music discovery
 - **Smart Color Extraction**: Dynamic color theming based on album artwork
-- **Visual Effects**: Customizable shimmer and glow effects for enhanced visual experience
+- **Visual Effects**: Streamlined visual effects system with simplified glow controls and customizable album filters
 - **Automatic Progression**: Seamless transitions between tracks with continuous playback
 - **Album Art Display**: Beautiful artwork display with customizable visual effects
 
@@ -245,6 +249,10 @@ public/
 - **Enhanced Styling**: Improved responsive design and visual consistency
 - **Better Error Handling**: More graceful error states and user feedback
 - **Optimized Icons**: Consistent 1.5rem sizing across all control icons
+- **Streamlined Visual Effects**: Simplified visual effects system with intuitive three-option controls (Less/Normal/More)
+- **Simplified Glow Controls**: Removed complex per-album glow settings in favor of unified global controls
+- **Enhanced Filter Options**: Refined brightness, saturation, sepia, and contrast ranges for better visual results
+- **Improved Settings Persistence**: Visual effects settings are preserved when toggling effects on/off
 
 ## Deployment
 

--- a/src/components/AccentColorGlowOverlay.tsx
+++ b/src/components/AccentColorGlowOverlay.tsx
@@ -8,7 +8,7 @@ interface AccentColorGlowOverlayProps {
   backgroundImage?: string;
 }
 
-export const DEFAULT_GLOW_RATE = 3.5;
+export const DEFAULT_GLOW_RATE = 2.5;
 
 const GlowBackgroundLayer = styled.div<{
   $glowIntensity: number;

--- a/src/components/AccentColorGlowOverlay.tsx
+++ b/src/components/AccentColorGlowOverlay.tsx
@@ -8,8 +8,8 @@ interface AccentColorGlowOverlayProps {
   backgroundImage?: string;
 }
 
-export const DEFAULT_GLOW_RATE = 4.5;
-export const DEFAULT_GLOW_INTENSITY = 100;
+export const DEFAULT_GLOW_RATE = 4.0;
+export const DEFAULT_GLOW_INTENSITY = 110;
 
 const GlowBackgroundLayer = styled.div<{
   $glowIntensity: number;

--- a/src/components/AccentColorGlowOverlay.tsx
+++ b/src/components/AccentColorGlowOverlay.tsx
@@ -8,7 +8,8 @@ interface AccentColorGlowOverlayProps {
   backgroundImage?: string;
 }
 
-export const DEFAULT_GLOW_RATE = 2.5;
+export const DEFAULT_GLOW_RATE = 4.5;
+export const DEFAULT_GLOW_INTENSITY = 100;
 
 const GlowBackgroundLayer = styled.div<{
   $glowIntensity: number;
@@ -51,7 +52,7 @@ const areGlowPropsEqual = (
 };
 
 export const AccentColorGlowOverlay = React.memo<React.FC<AccentColorGlowOverlayProps>>(({
-  glowIntensity,
+  glowIntensity = DEFAULT_GLOW_INTENSITY,
   glowRate = DEFAULT_GLOW_RATE,
   accentColor,
   backgroundImage

--- a/src/components/AlbumArt.tsx
+++ b/src/components/AlbumArt.tsx
@@ -47,7 +47,6 @@ interface AlbumArtProps {
     hue: number;
     blur: number;
     sepia: number;
-    invert: number;
   };
 }
 
@@ -88,7 +87,7 @@ const arePropsEqual = (prevProps: AlbumArtProps, nextProps: AlbumArtProps): bool
     return false;
   }
   const filterKeys: (keyof typeof prevProps.albumFilters)[] = [
-    'brightness', 'contrast', 'saturation', 'blur', 'sepia', 'invert'
+    'brightness', 'contrast', 'saturation', 'blur', 'sepia'
   ];
   for (const key of filterKeys) {
     if (prevProps.albumFilters[key] !== nextProps.albumFilters[key]) {
@@ -173,15 +172,13 @@ const AlbumArt: React.FC<AlbumArtProps> = memo(({ currentTrack = null, accentCol
       glowRate={glowRate}
       className={glowClasses}
     >
-      <AlbumArtFilters filters={albumFilters ? { ...albumFilters, invert: !!albumFilters.invert } : {
+      <AlbumArtFilters filters={albumFilters ? albumFilters : {
         brightness: 100,
         contrast: 100,
         saturation: 100,
         hue: 0,
         blur: 0,
-        sepia: 0,
-
-        invert: false,
+        sepia: 0
       }}>
         <AccentColorGlowOverlay
           glowIntensity={glowIntensity ?? 100}

--- a/src/components/AlbumArt.tsx
+++ b/src/components/AlbumArt.tsx
@@ -47,7 +47,6 @@ interface AlbumArtProps {
     hue: number;
     blur: number;
     sepia: number;
-    grayscale: number;
     invert: number;
   };
 }
@@ -89,7 +88,7 @@ const arePropsEqual = (prevProps: AlbumArtProps, nextProps: AlbumArtProps): bool
     return false;
   }
   const filterKeys: (keyof typeof prevProps.albumFilters)[] = [
-    'brightness', 'contrast', 'saturation', 'blur', 'sepia', 'grayscale', 'invert'
+    'brightness', 'contrast', 'saturation', 'blur', 'sepia', 'invert'
   ];
   for (const key of filterKeys) {
     if (prevProps.albumFilters[key] !== nextProps.albumFilters[key]) {
@@ -181,7 +180,7 @@ const AlbumArt: React.FC<AlbumArtProps> = memo(({ currentTrack = null, accentCol
         hue: 0,
         blur: 0,
         sepia: 0,
-        grayscale: 0,
+
         invert: false,
       }}>
         <AccentColorGlowOverlay

--- a/src/components/AlbumArt.tsx
+++ b/src/components/AlbumArt.tsx
@@ -2,7 +2,7 @@ import React, { memo, useEffect, useState, useCallback } from 'react';
 import styled, { keyframes } from 'styled-components';
 import type { Track } from '../services/spotify';
 import AlbumArtFilters from './AlbumArtFilters';
-import AccentColorGlowOverlay, { hexToRgb, DEFAULT_GLOW_RATE } from './AccentColorGlowOverlay';
+import AccentColorGlowOverlay, { hexToRgb, DEFAULT_GLOW_RATE, DEFAULT_GLOW_INTENSITY } from './AccentColorGlowOverlay';
 import { useImageProcessingWorker } from '../hooks/useImageProcessingWorker';
 
 const spin = keyframes`
@@ -173,15 +173,13 @@ const AlbumArt: React.FC<AlbumArtProps> = memo(({ currentTrack = null, accentCol
       className={glowClasses}
     >
       <AlbumArtFilters filters={albumFilters ? albumFilters : {
-        brightness: 100,
+        brightness: 110,
         contrast: 100,
         saturation: 100,
-        hue: 0,
-        blur: 0,
         sepia: 0
       }}>
         <AccentColorGlowOverlay
-          glowIntensity={glowIntensity ?? 100}
+          glowIntensity={glowIntensity ?? DEFAULT_GLOW_INTENSITY}
           glowRate={glowRate ?? DEFAULT_GLOW_RATE}
           accentColor={accentColor || '#000000'}
           backgroundImage={currentTrack?.image}

--- a/src/components/AlbumArt.tsx
+++ b/src/components/AlbumArt.tsx
@@ -89,7 +89,7 @@ const arePropsEqual = (prevProps: AlbumArtProps, nextProps: AlbumArtProps): bool
     return false;
   }
   const filterKeys: (keyof typeof prevProps.albumFilters)[] = [
-    'brightness', 'contrast', 'saturation', 'hue', 'blur', 'sepia', 'grayscale', 'invert'
+    'brightness', 'contrast', 'saturation', 'blur', 'sepia', 'grayscale', 'invert'
   ];
   for (const key of filterKeys) {
     if (prevProps.albumFilters[key] !== nextProps.albumFilters[key]) {

--- a/src/components/AlbumArtFilters.tsx
+++ b/src/components/AlbumArtFilters.tsx
@@ -34,7 +34,6 @@ export const AlbumArtFilters: React.FC<AlbumArtFiltersProps> = ({
     `brightness(${filters.brightness}%)`,
     `contrast(${filters.contrast}%)`,
     `saturate(${filters.saturation}%)`,
-    `hue-rotate(${filters.hue}deg)`,
     `blur(${filters.blur}px)`,
     `sepia(${filters.sepia}%)`,
     `grayscale(${filters.grayscale}%)`,

--- a/src/components/AlbumArtFilters.tsx
+++ b/src/components/AlbumArtFilters.tsx
@@ -9,7 +9,6 @@ interface AlbumArtFiltersProps {
     hue: number;
     blur: number;
     sepia: number;
-    grayscale: number;
     invert: boolean;
   };
   backgroundImage?: string;
@@ -36,7 +35,6 @@ export const AlbumArtFilters: React.FC<AlbumArtFiltersProps> = ({
     `saturate(${filters.saturation}%)`,
     `blur(${filters.blur}px)`,
     `sepia(${filters.sepia}%)`,
-    `grayscale(${filters.grayscale}%)`,
     `invert(${filters.invert ? 100 : 0}%)`
   ].join(' ');
 

--- a/src/components/AlbumArtFilters.tsx
+++ b/src/components/AlbumArtFilters.tsx
@@ -9,7 +9,6 @@ interface AlbumArtFiltersProps {
     hue: number;
     blur: number;
     sepia: number;
-    invert: boolean;
   };
   backgroundImage?: string;
   className?: string;
@@ -34,8 +33,7 @@ export const AlbumArtFilters: React.FC<AlbumArtFiltersProps> = ({
     `contrast(${filters.contrast}%)`,
     `saturate(${filters.saturation}%)`,
     `blur(${filters.blur}px)`,
-    `sepia(${filters.sepia}%)`,
-    `invert(${filters.invert ? 100 : 0}%)`
+    `sepia(${filters.sepia}%)`
   ].join(' ');
 
   return (

--- a/src/components/AlbumArtFilters.tsx
+++ b/src/components/AlbumArtFilters.tsx
@@ -6,8 +6,6 @@ interface AlbumArtFiltersProps {
     brightness: number;
     contrast: number;
     saturation: number;
-    hue: number;
-    blur: number;
     sepia: number;
   };
   backgroundImage?: string;
@@ -32,7 +30,6 @@ export const AlbumArtFilters: React.FC<AlbumArtFiltersProps> = ({
     `brightness(${filters.brightness}%)`,
     `contrast(${filters.contrast}%)`,
     `saturate(${filters.saturation}%)`,
-    `blur(${filters.blur}px)`,
     `sepia(${filters.sepia}%)`
   ].join(' ');
 

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -428,8 +428,7 @@ const AudioPlayerComponent = () => {
               saturation: 100,
               hue: 0,
               blur: 0,
-              sepia: 0,
-              invert: 0
+              sepia: 0
             }} />
           </CardContent>
           <CardContent style={{ position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 2 }}>

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -344,10 +344,8 @@ const AudioPlayerComponent = () => {
 
   const handleVisualEffectsToggle = useCallback(() => {
     if (visualEffectsEnabled) {
-      // Turning off visual effects - just disable them, settings are already saved
       setVisualEffectsEnabled(false);
     } else {
-      // Turning on visual effects - restore saved settings or keep defaults
       setVisualEffectsEnabled(true);
       restoreSavedFilters();
       if (savedGlowIntensity !== null) {
@@ -423,7 +421,7 @@ const AudioPlayerComponent = () => {
 
           <CardContent style={{ position: 'relative', zIndex: 2, marginTop: '-0.25rem' }}>
             <AlbumArt currentTrack={currentTrack} accentColor={accentColor} glowIntensity={visualEffectsEnabled ? effectiveGlow.intensity : 0} glowRate={effectiveGlow.rate} albumFilters={visualEffectsEnabled ? albumFilters : {
-              brightness: 100,
+              brightness: 110,
               contrast: 100,
               saturation: 100,
               hue: 0,

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useCallback, lazy, Suspense } from 'react';
+import { useEffect, useMemo, useCallback, lazy, Suspense, useState } from 'react';
 import styled from 'styled-components';
 import { spotifyAuth } from '../services/spotify';
 import { spotifyPlayer } from '../services/spotifyPlayer';
@@ -14,7 +14,8 @@ import PlayerStateRenderer from './PlayerStateRenderer';
 import { usePlayerState } from '../hooks/usePlayerState';
 import { usePlaylistManager } from '../hooks/usePlaylistManager';
 import { theme } from '@/styles/theme';
-import { DEFAULT_GLOW_RATE } from './AccentColorGlowOverlay';
+import { DEFAULT_GLOW_RATE, DEFAULT_GLOW_INTENSITY } from './AccentColorGlowOverlay';
+
 
 const Container = styled.div`
   width: 100%;
@@ -102,11 +103,12 @@ const AudioPlayerComponent = () => {
     showPlaylist,
     accentColor,
     showVisualEffects,
-    glowEnabled,
-    glowIntensity,
-    glowRate,
-    glowMode,
-    perAlbumGlow,
+    visualEffectsEnabled,
+    setVisualEffectsEnabled,
+
+
+
+
     accentColorOverrides,
     albumFilters,
     setTracks,
@@ -117,15 +119,34 @@ const AudioPlayerComponent = () => {
     setShowPlaylist,
     setAccentColor,
     setShowVisualEffects,
-    setGlowEnabled,
-    setGlowIntensity,
-    setGlowRate,
-    setGlowMode,
-    setPerAlbumGlow,
+
+
+
     setAccentColorOverrides,
     handleFilterChange,
     handleResetFilters,
+    restoreSavedFilters,
   } = usePlayerState();
+
+  // Global glow state (these will be managed by the VisualEffectsMenu)
+  const [glowIntensity, setGlowIntensity] = useState(DEFAULT_GLOW_INTENSITY); // Medium
+  const [glowRate, setGlowRate] = useState(DEFAULT_GLOW_RATE);
+  const [savedGlowIntensity, setSavedGlowIntensity] = useState<number | null>(null);
+  const [savedGlowRate, setSavedGlowRate] = useState<number | null>(null);
+
+  // Use global glow settings
+  const effectiveGlow = { intensity: glowIntensity, rate: glowRate };
+
+  // Wrapper functions that save settings when glow values change
+  const handleGlowIntensityChange = useCallback((intensity: number) => {
+    setGlowIntensity(intensity);
+    setSavedGlowIntensity(intensity);
+  }, []);
+
+  const handleGlowRateChange = useCallback((rate: number) => {
+    setGlowRate(rate);
+    setSavedGlowRate(rate);
+  }, []);
 
   const playTrack = useCallback(async (index: number) => {
     if (tracks[index]) {
@@ -321,9 +342,22 @@ const AudioPlayerComponent = () => {
     setShowVisualEffects(false);
   }, []);
 
-  const handleGlowToggle = useCallback(() => {
-    setGlowEnabled(!glowEnabled);
-  }, [glowEnabled]);
+  const handleVisualEffectsToggle = useCallback(() => {
+    if (visualEffectsEnabled) {
+      // Turning off visual effects - just disable them, settings are already saved
+      setVisualEffectsEnabled(false);
+    } else {
+      // Turning on visual effects - restore saved settings or keep defaults
+      setVisualEffectsEnabled(true);
+      restoreSavedFilters();
+      if (savedGlowIntensity !== null) {
+        setGlowIntensity(savedGlowIntensity);
+      }
+      if (savedGlowRate !== null) {
+        setGlowRate(savedGlowRate);
+      }
+    }
+  }, [visualEffectsEnabled, restoreSavedFilters, savedGlowIntensity, savedGlowRate]);
 
   const handleClosePlaylist = useCallback(() => {
     setShowPlaylist(false);
@@ -362,12 +396,6 @@ const AudioPlayerComponent = () => {
     }
   }, [currentTrack?.id, currentTrack?.image, setAccentColorOverrides, setAccentColor, theme.colors.accent]);
 
-  const currentAlbumId = currentTrack?.album || '';
-  const currentAlbumName = currentTrack?.album || '';
-  const effectiveGlow = glowMode === 'per-album' && currentAlbumId && perAlbumGlow[currentAlbumId]
-    ? perAlbumGlow[currentAlbumId]
-    : { intensity: glowIntensity, rate: glowRate };
-
   const renderContent = () => {
     const stateRenderer = (
       <PlayerStateRenderer
@@ -388,13 +416,21 @@ const AudioPlayerComponent = () => {
         <LoadingCard
           backgroundImage={currentTrack?.image}
           accentColor={accentColor}
-          glowEnabled={glowEnabled}
+          glowEnabled={visualEffectsEnabled}
           glowIntensity={effectiveGlow.intensity}
           glowRate={effectiveGlow.rate}
         >
 
           <CardContent style={{ position: 'relative', zIndex: 2, marginTop: '-0.25rem' }}>
-            <AlbumArt currentTrack={currentTrack} accentColor={accentColor} glowIntensity={glowEnabled ? effectiveGlow.intensity : 0} glowRate={effectiveGlow.rate} albumFilters={albumFilters} />
+            <AlbumArt currentTrack={currentTrack} accentColor={accentColor} glowIntensity={visualEffectsEnabled ? effectiveGlow.intensity : 0} glowRate={effectiveGlow.rate} albumFilters={visualEffectsEnabled ? albumFilters : {
+              brightness: 100,
+              contrast: 100,
+              saturation: 100,
+              hue: 0,
+              blur: 0,
+              sepia: 0,
+              invert: 0
+            }} />
           </CardContent>
           <CardContent style={{ position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 2 }}>
             <Suspense fallback={<div style={{ height: '80px', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'rgba(255,255,255,0.7)' }}>Loading controls...</div>}>
@@ -409,12 +445,12 @@ const AudioPlayerComponent = () => {
                 trackCount={tracks.length}
                 onAccentColorChange={handleAccentColorChange}
                 onShowVisualEffects={handleShowVisualEffects}
-                glowEnabled={glowEnabled}
-                onGlowToggle={handleGlowToggle}
+                glowEnabled={visualEffectsEnabled}
+                onGlowToggle={handleVisualEffectsToggle}
               />
             </Suspense>
           </CardContent>
-          <Suspense fallback={<div>Loading effects...</div>}>
+          {visualEffectsEnabled && <Suspense fallback={<div>Loading effects...</div>}>
             <VisualEffectsMenu
               isOpen={showVisualEffects}
               onClose={handleCloseVisualEffects}
@@ -422,21 +458,13 @@ const AudioPlayerComponent = () => {
               filters={albumFilters}
               onFilterChange={handleFilterChange}
               onResetFilters={handleResetFilters}
-              glowEnabled={glowEnabled}
-              setGlowEnabled={setGlowEnabled}
               glowIntensity={glowIntensity}
-              setGlowIntensity={setGlowIntensity}
-              glowRate={typeof glowRate === 'number' ? glowRate : DEFAULT_GLOW_RATE}
-              setGlowRate={setGlowRate}
-              glowMode={glowMode}
-              setGlowMode={setGlowMode}
-              perAlbumGlow={perAlbumGlow}
-              setPerAlbumGlow={setPerAlbumGlow}
-              currentAlbumId={currentAlbumId}
-              currentAlbumName={currentAlbumName}
+              setGlowIntensity={handleGlowIntensityChange}
+              glowRate={glowRate}
+              setGlowRate={handleGlowRateChange}
               effectiveGlow={effectiveGlow}
             />
-          </Suspense>
+          </Suspense>}
         </LoadingCard>
 
         <Suspense fallback={<div style={{ position: 'fixed', top: 0, right: 0, bottom: 0, width: '400px', background: 'rgba(0,0,0,0.8)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'rgba(255,255,255,0.7)' }}>Loading playlist...</div>}>

--- a/src/components/SpotifyPlayerControls.tsx
+++ b/src/components/SpotifyPlayerControls.tsx
@@ -158,30 +158,30 @@ const areControlsPropsEqual = (
   if (prevProps.currentTrack?.id !== nextProps.currentTrack?.id) {
     return false;
   }
-  
+
   // Check accent color
   if (prevProps.accentColor !== nextProps.accentColor) {
     return false;
   }
-  
+
   // Check glow settings
   if (prevProps.glowEnabled !== nextProps.glowEnabled) {
     return false;
   }
-  
+
   // Check visual effects state
   if (prevProps.showVisualEffects !== nextProps.showVisualEffects) {
     return false;
   }
-  
+
   // Check track count for playlist display
   if (prevProps.trackCount !== nextProps.trackCount) {
     return false;
   }
-  
+
   // For callbacks, we assume they're stable (parent should use useCallback)
   // This prevents unnecessary re-renders due to function reference changes
-  
+
   return true;
 };
 
@@ -337,23 +337,13 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({ currentTrack, 
       {/* Timeline Row with time, slider, and right controls */}
       <TimelineRow>
         <TimelineLeft>
-          <LikeButton
-            trackId={currentTrack?.id}
-            isLiked={isLiked}
-            isLoading={isLikePending}
-            accentColor={accentColor}
-            onToggleLike={handleLikeToggle}
-          />
-
-
-          {/* Add glow toggle button */}
           {onGlowToggle && (
             <ControlButton
               accentColor={accentColor}
-              onClick={onGlowToggle}
               isActive={glowEnabled}
-              title={`Glow ${glowEnabled ? 'enabled' : 'disabled'}`}
-              data-testid="glow-toggle"
+              title={`Visual Effects ${glowEnabled ? 'enabled' : 'disabled'}`}
+              onClick={onGlowToggle}
+              style={{ marginLeft: 8 }}
             >
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <circle cx="12" cy="12" r="9" />
@@ -362,6 +352,24 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({ currentTrack, 
               </svg>
             </ControlButton>
           )}
+          <ControlButton
+            accentColor={accentColor}
+            onClick={onShowVisualEffects}
+            isActive={showVisualEffects}
+            title="Visual effects"
+            data-testid="visual-effects-button"
+          >
+            <svg viewBox="0 0 24 24" style={{ display: 'block' }} width="1.5rem" height="1.5rem" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                fill="currentColor"
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M19.43 12.98c.04-.32.07-.65.07-.98s-.03-.66-.07-.98l2.11-1.65a.5.5 0 00.12-.64l-2-3.46a.5.5 0 00-.6-.22l-2.49 1a7.03 7.03 0 00-1.7-.98l-.38-2.65A.488.488 0 0014 2h-4a.488.488 0 00-.5.42l-.38 2.65c-.63.25-1.21.57-1.77.98l-2.49-1a.5.5 0 00-.6.22l-2 3.46a.5.5 0 00.12.64l2.11 1.65c-.05.32-.08.65-.08.99s.03.67.08.99l-2.11 1.65a.5.5 0 00-.12.64l2 3.46c.14.24.44.33.7.22l2.49-1c.54.41 1.13.74 1.77.98l.38 2.65c.05.28.27.42.5.42h4c.23 0 .45-.14.5-.42l.38-2.65c.63-.25 1.22-.57 1.77-.98l2.49 1c.26.11.56.02.7-.22l2-3.46a.5.5 0 00-.12-.64l-2.11-1.65zM12 15.5A3.5 3.5 0 1112 8.5a3.5 3.5 0 010 7z"
+              />
+              <circle cx="12" cy="12" r="2" fill="#fff" />
+            </svg>
+          </ControlButton>
+
           <Suspense fallback={<div style={{ width: '40px', height: '40px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>⚡</div>}>
             <ColorPickerPopover
               accentColor={accentColor}
@@ -403,23 +411,15 @@ const SpotifyPlayerControls = memo<SpotifyPlayerControlsProps>(({ currentTrack, 
         />
 
         <TimelineRight>
-          <ControlButton 
-            accentColor={accentColor} 
-            onClick={onShowVisualEffects} 
-            isActive={showVisualEffects} 
-            title="Visual effects"
-            data-testid="visual-effects-button"
-          >
-            <svg viewBox="0 0 24 24" style={{ display: 'block' }} width="1.5rem" height="1.5rem" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path
-                fill="currentColor"
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M19.43 12.98c.04-.32.07-.65.07-.98s-.03-.66-.07-.98l2.11-1.65a.5.5 0 00.12-.64l-2-3.46a.5.5 0 00-.6-.22l-2.49 1a7.03 7.03 0 00-1.7-.98l-.38-2.65A.488.488 0 0014 2h-4a.488.488 0 00-.5.42l-.38 2.65c-.63.25-1.21.57-1.77.98l-2.49-1a.5.5 0 00-.6.22l-2 3.46a.5.5 0 00.12.64l2.11 1.65c-.05.32-.08.65-.08.99s.03.67.08.99l-2.11 1.65a.5.5 0 00-.12.64l2 3.46c.14.24.44.33.7.22l2.49-1c.54.41 1.13.74 1.77.98l.38 2.65c.05.28.27.42.5.42h4c.23 0 .45-.14.5-.42l.38-2.65c.63-.25 1.22-.57 1.77-.98l2.49 1c.26.11.56.02.7-.22l2-3.46a.5.5 0 00-.12-.64l-2.11-1.65zM12 15.5A3.5 3.5 0 1112 8.5a3.5 3.5 0 010 7z"
-              />
-              <circle cx="12" cy="12" r="2" fill="#fff" />
-            </svg>
-          </ControlButton>
+          <LikeButton
+            trackId={currentTrack?.id}
+            isLiked={isLiked}
+            isLoading={isLikePending}
+            accentColor={accentColor}
+            onToggleLike={handleLikeToggle}
+          />
+
+
         </TimelineRight>
       </TimelineRow>
     </PlayerControlsContainer>

--- a/src/components/VisualEffectsMenu.tsx
+++ b/src/components/VisualEffectsMenu.tsx
@@ -255,8 +255,7 @@ export const VisualEffectsMenu: React.FC<VisualEffectsMenuProps> = memo(({
   glowIntensity,
   setGlowIntensity,
   glowRate,
-  setGlowRate,
-  effectiveGlow
+  setGlowRate
 }) => {
   // Add ESC key support to close the drawer
   useEffect(() => {

--- a/src/components/VisualEffectsMenu.tsx
+++ b/src/components/VisualEffectsMenu.tsx
@@ -116,53 +116,6 @@ const ControlLabel = styled.label`
   font-weight: 500;
 `;
 
-const ControlValue = styled.span`
-  font-size: 0.75rem;
-  color: rgba(255, 255, 255, 0.6);
-  font-weight: 400;
-`;
-
-const Slider = styled.input<{ $accentColor: string }>`
-  appearance: none;
-  width: 100%;
-  height: 4px;
-  background: ${theme.colors.control.background};
-  border-radius: ${theme.borderRadius.sm};
-  outline: none;
-  cursor: pointer;
-  
-  &::-webkit-slider-thumb {
-    appearance: none;
-    width: 16px;
-    height: 16px;
-    background: ${({ $accentColor }: { $accentColor: string }) => $accentColor};
-    border-radius: 50%;
-    cursor: pointer;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-    transition: all 0.2s ease;
-  }
-  
-  &::-webkit-slider-thumb:hover {
-    transform: scale(1.2);
-    box-shadow: 0 0 0 4px ${({ $accentColor }: { $accentColor: string }) => $accentColor}33;
-  }
-  
-  &::-moz-range-thumb {
-    width: 16px;
-    height: 16px;
-    background: ${({ $accentColor }: { $accentColor: string }) => $accentColor};
-    border-radius: 50%;
-    cursor: pointer;
-    border: none;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-    transition: all 0.2s ease;
-  }
-  
-  &::-moz-range-thumb:hover {
-    transform: scale(1.2);
-    box-shadow: 0 0 0 4px ${({ $accentColor }: { $accentColor: string }) => $accentColor}33;
-  }
-`;
 
 const FilterSection = styled.div`
   border-top: 1px solid rgba(255, 255, 255, 0.1);
@@ -226,24 +179,6 @@ const ResetButton = styled.button<{ $accentColor: string }>`
   }
 `;
 
-const ToggleButton = styled.button<{ $accentColor: string; $isActive: boolean }>`
-  background: ${({ $isActive, $accentColor }: { $isActive: boolean; $accentColor: string }) => $isActive ? $accentColor : theme.colors.muted.background};
-  border: 1px solid ${({ $isActive, $accentColor }: { $isActive: boolean; $accentColor: string }) => $isActive ? $accentColor : theme.colors.border};
-  color: ${({ $isActive }: { $isActive: boolean }) => $isActive ? theme.colors.black : theme.colors.muted.foreground};
-  padding: ${theme.spacing.sm} ${theme.spacing.md};
-  border-radius: ${theme.borderRadius.md};
-  cursor: pointer;
-  font-size: ${theme.fontSize.sm};
-  font-weight: ${theme.fontWeight.medium};
-  transition: all 0.2s ease;
-  
-  &:hover {
-    background: ${({ $isActive, $accentColor }: { $isActive: boolean; $accentColor: string }) => $isActive ? $accentColor + 'DD' : $accentColor + '22'};
-    border-color: ${({ $accentColor }: { $accentColor: string }) => $accentColor};
-    color: ${({ $isActive }: { $isActive: boolean }) => $isActive ? theme.colors.black : theme.colors.white};
-    transform: translateY(-1px);
-  }
-`;
 
 const OptionButtonGroup = styled.div`
   display: flex;
@@ -399,20 +334,6 @@ export const VisualEffectsMenu: React.FC<VisualEffectsMenuProps> = memo(({
     { label: 'Fast', value: 3.0 }
   ];
 
-  // Helper functions to get current option labels
-  const getCurrentGlowIntensityLabel = useCallback((value: number) => {
-    const closest = glowIntensityOptions.reduce((prev, curr) =>
-      Math.abs(curr.value - value) < Math.abs(prev.value - value) ? curr : prev
-    );
-    return closest.label;
-  }, []);
-
-  const getCurrentGlowRateLabel = useCallback((value: number) => {
-    const closest = glowRateOptions.reduce((prev, curr) =>
-      Math.abs(curr.value - value) < Math.abs(prev.value - value) ? curr : prev
-    );
-    return closest.label;
-  }, []);
 
   const getCurrentFilterOptionLabel = useCallback((key: string, value: number) => {
     const config = filterConfig.find(f => f.key === key);

--- a/src/components/VisualEffectsMenu.tsx
+++ b/src/components/VisualEffectsMenu.tsx
@@ -323,15 +323,15 @@ export const VisualEffectsMenu: React.FC<VisualEffectsMenuProps> = memo(({
 
   // Glow intensity and rate option mappings
   const glowIntensityOptions = [
-    { label: 'Low', value: 90 },
-    { label: 'Medium', value: 100 },
-    { label: 'High', value: 110 }
+    { label: 'Less', value: 95 },
+    { label: 'Normal', value: 110 },
+    { label: 'More', value: 125 }
   ];
 
   const glowRateOptions = [
-    { label: 'Slow', value: 6.0 },
-    { label: 'Medium', value: 4.5 },
-    { label: 'Fast', value: 3.0 }
+    { label: 'Slower', value: 5.0 },
+    { label: 'Normal', value: 4.0 },
+    { label: 'Faster', value: 3.0 }
   ];
 
 

--- a/src/components/VisualEffectsMenu.tsx
+++ b/src/components/VisualEffectsMenu.tsx
@@ -16,7 +16,6 @@ interface VisualEffectsMenuProps {
     saturation: number;
     hue: number;
     sepia: number;
-    invert: number;
   };
   onFilterChange: (filterName: string, value: number | boolean) => void;
   onResetFilters: () => void;
@@ -289,7 +288,7 @@ const areVisualEffectsPropsEqual = (
 
   // Check filters object
   const filterKeys: (keyof typeof prevProps.filters)[] = [
-    'brightness', 'contrast', 'saturation', 'sepia', 'invert'
+    'brightness', 'contrast', 'saturation', 'sepia'
   ];
 
   for (const key of filterKeys) {
@@ -384,8 +383,7 @@ export const VisualEffectsMenu: React.FC<VisualEffectsMenuProps> = memo(({
         { label: 'Normal', value: 100 },
         { label: 'More', value: 115 }
       ]
-    },
-    { key: 'invert', label: 'Invert', min: 0, max: 1, unit: '', type: 'toggle' as const }
+    }
   ], []);
 
   // Glow intensity and rate option mappings
@@ -427,11 +425,6 @@ export const VisualEffectsMenu: React.FC<VisualEffectsMenuProps> = memo(({
     return value.toString();
   }, [filterConfig]);
 
-  // Optimized callbacks with minimal dependencies
-  const handleInvertToggle = useCallback(() => {
-    onFilterChange('invert', filters.invert === 0 ? 1 : 0);
-  }, [filters.invert, onFilterChange]);
-
   const handleFilterChange = useCallback((key: string, value: number) => {
     onFilterChange(key, value);
   }, [onFilterChange]);
@@ -448,28 +441,6 @@ export const VisualEffectsMenu: React.FC<VisualEffectsMenuProps> = memo(({
 
     // Use optimized filter value getter
     const currentValue = getFilterValue(key);
-
-    if (type === 'toggle') {
-      return (
-        <div style={style} key={`filter-${key}`}>
-          <FilterItem>
-            <ControlGroup>
-              <ControlLabel>
-                {label}
-                <ToggleButton
-                  $accentColor={accentColor}
-                  $isActive={currentValue === 1}
-                  onClick={handleInvertToggle}
-                  aria-label={`Toggle ${label}`}
-                >
-                  {currentValue === 1 ? 'On' : 'Off'}
-                </ToggleButton>
-              </ControlLabel>
-            </ControlGroup>
-          </FilterItem>
-        </div>
-      );
-    }
 
     if (type === 'options') {
       return (
@@ -499,30 +470,9 @@ export const VisualEffectsMenu: React.FC<VisualEffectsMenuProps> = memo(({
       );
     }
 
-    // Default slider for remaining options (none currently)
-    const { min, max, unit } = config;
-    return (
-      <div style={style} key={`filter-${key}`}>
-        <FilterItem>
-          <ControlGroup>
-            <ControlLabel>
-              {label}
-              <ControlValue>{currentValue}{unit}</ControlValue>
-            </ControlLabel>
-            <Slider
-              type="range"
-              min={min}
-              max={max}
-              value={currentValue}
-              onChange={(e) => handleFilterChange(key, parseInt(e.target.value))}
-              $accentColor={accentColor}
-              aria-label={`Adjust ${label}`}
-            />
-          </ControlGroup>
-        </FilterItem>
-      </div>
-    );
-  }, [filterConfig, accentColor, handleInvertToggle, handleFilterChange, getFilterValue, getCurrentFilterOptionLabel]);
+    // Should not reach here since all filters are options type
+    return null;
+  }, [filterConfig, accentColor, handleFilterChange, getFilterValue, getCurrentFilterOptionLabel]);
 
   return (
     <PerformanceProfilerComponent id="visual-effects-menu">
@@ -548,8 +498,8 @@ export const VisualEffectsMenu: React.FC<VisualEffectsMenuProps> = memo(({
             <FilterGrid>
               <ControlGroup>
                 <ControlLabel>
-                  Glow Intensity
-                  <ControlValue>{getCurrentGlowIntensityLabel(glowIntensity)}</ControlValue>
+                  Intensity
+                  {/* <ControlValue>{getCurrentGlowIntensityLabel(glowIntensity)}</ControlValue> */}
                 </ControlLabel>
                 <OptionButtonGroup>
                   {glowIntensityOptions.map((option) => (
@@ -566,8 +516,8 @@ export const VisualEffectsMenu: React.FC<VisualEffectsMenuProps> = memo(({
               </ControlGroup>
               <ControlGroup>
                 <ControlLabel>
-                  Glow Rate
-                  <ControlValue>{getCurrentGlowRateLabel(glowRate)}</ControlValue>
+                  Rate
+                  {/* <ControlValue>{getCurrentGlowRateLabel(glowRate)}</ControlValue> */}
                 </ControlLabel>
                 <OptionButtonGroup>
                   {glowRateOptions.map((option) => (
@@ -582,9 +532,6 @@ export const VisualEffectsMenu: React.FC<VisualEffectsMenuProps> = memo(({
                   ))}
                 </OptionButtonGroup>
               </ControlGroup>
-              <div style={{ fontSize: '0.8rem', color: '#aaa', marginBottom: '0.5rem' }}>
-                Effective: Intensity {getCurrentGlowIntensityLabel(effectiveGlow.intensity)}, Rate {getCurrentGlowRateLabel(effectiveGlow.rate)}
-              </div>
             </FilterGrid>
           </FilterSection>
           <FilterSection>

--- a/src/hooks/usePlayerState.ts
+++ b/src/hooks/usePlayerState.ts
@@ -10,7 +10,6 @@ export interface AlbumFilters {
   hue: number;
   blur: number;
   sepia: number;
-  invert: number;
 }
 
 export interface PlayerState {
@@ -64,9 +63,7 @@ export const usePlayerState = () => {
           saturation: parsed.saturation ?? 100,
           hue: parsed.hue ?? 0,
           blur: parsed.blur ?? 0,
-          sepia: parsed.sepia ?? 0,
-    
-          invert: typeof parsed.invert === 'boolean' ? (parsed.invert ? 1 : 0) : parsed.invert
+          sepia: parsed.sepia ?? 0
         };
       } catch (e) {
         return {
@@ -75,9 +72,7 @@ export const usePlayerState = () => {
           saturation: 100,
           hue: 0,
           blur: 0,
-          sepia: 0,
-
-          invert: 0
+          sepia: 0
         };
       }
     }
@@ -87,9 +82,7 @@ export const usePlayerState = () => {
       saturation: 100,
       hue: 0,
       blur: 0,
-      sepia: 0,
-
-      invert: 0
+      sepia: 0
     };
   });
 
@@ -139,8 +132,7 @@ export const usePlayerState = () => {
       saturation: 100,
       hue: 0,
       blur: 0,
-      sepia: 0,
-      invert: 0
+      sepia: 0
     });
   }, []);
 

--- a/src/styles/glow-animations.css
+++ b/src/styles/glow-animations.css
@@ -18,25 +18,25 @@
       drop-shadow(0 8px 12px rgba(23, 22, 22, 0.5))
       drop-shadow(0 2px 8px rgba(22, 21, 21, 0.6))
       drop-shadow(0 2px 158px rgba(var(--accent-rgb), calc(var(--glow-intensity) /150)));
-    transform: scale(0.999);
+      transform: scale(1);
   }
   50% {
     filter: 
       drop-shadow(0 12px 12px rgba(23, 22, 22, 0.4))
       drop-shadow(0 4px 8px rgba(22, 21, 21, 0.8))
       drop-shadow(0 4px 188px rgba(var(--accent-rgb), calc(var(--glow-intensity) / 500)));
-    transform: scale(1);
+      transform: scale(0.999);
   }
 }
 
 @keyframes breathe-glow {
   0%, 100% {
-    filter: brightness(0.9);
+    filter: brightness(calc(var(--glow-intensity) / 100));
     opacity: calc(var(--glow-intensity) / 100);
     transform: translateZ(0);
   }
   50% {
-    filter: brightness(calc(var(--glow-intensity) / 100));
+    filter: brightness(0.9);
     opacity: calc(var(--glow-intensity) / 100);
     transform: translateZ(0);
   }


### PR DESCRIPTION
Refactor visual effects menu to use simplified 3-option controls and remove hue rotate.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents%3Fid=bc-e9cd464f-5a10-4d0a-808f-9384ab2ac522) · [Cursor](https://cursor.com/background-agent%3FbcId=bc-e9cd464f-5a10-4d0a-808f-9384ab2ac522)